### PR TITLE
Modified WMTS Resource URL generation to support hostnames that contain the layer name.

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -1031,7 +1031,7 @@ class Wmts extends Server {
         $maxMercatorZoom = max($maxMercatorZoom, $m['maxzoom']);
       }
 
-      $wmtsHost = substr($m['tiles'][0], 0, strpos($m['tiles'][0], $m['basename']));
+      $wmtsHost = substr($m['tiles'][0], 0, strrpos($m['tiles'][0], $m['basename']));
       $resourceUrlTemplate = $wmtsHost . $basename
               . '/{TileMatrix}/{TileCol}/{TileRow}';
       if(strlen($format) <= 4){


### PR DESCRIPTION

If the hostname contained the layer name (eg. https://layername.domain.com/layername/wmts) then the WMTS capabilities document contained an incorrect Resource URL because the hostname was stripped back to simply https://.  This modification simply looks for the last occurrence of the layer name instead of the first when forming the Resource URL.